### PR TITLE
Add quotes to `system` Table name, to avoid naming conflicts

### DIFF
--- a/src/Entity/SystemKeyEntity.php
+++ b/src/Entity/SystemKeyEntity.php
@@ -24,7 +24,7 @@ use jonasarts\Bundle\RegistryBundle\Entity\SystemKeyInterface;
  * Doctrine-mapped SystemKey entity
  *
  * @ORM\Entity()
- * @ORM\Table(name="system",
+ * @ORM\Table(name="`system`",
  *      uniqueConstraints={@ORM\UniqueConstraint(name="uix_key_name", columns={"systemkey", "name"})}
  * )
  * @UniqueEntity({"name", "systemkey"})


### PR DESCRIPTION
The table name `system` is reserved in some Databases. This causes any requests that use the registry to fail. Quoting the table name fixes this. 